### PR TITLE
Fix installation of jenkins-agent. Substitute Oracle JDK with OpenJDK 8

### DIFF
--- a/roles/jenkins-agent/tasks/main.yml
+++ b/roles/jenkins-agent/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: Install OpenJDK
+- name: Install OpenJDK 8 JRE
   apt:
-    name: openjdk-8-jdk
+    name: openjdk-8-jre
     state: present
 
 - name: Setup jenkins-agent

--- a/roles/jenkins-agent/tasks/main.yml
+++ b/roles/jenkins-agent/tasks/main.yml
@@ -1,27 +1,8 @@
 ---
 
-- name: Adding Oracle JDK apt key
-  apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: "{{ jenkins_agent_oracle_jdk_key_id }}"
-    state: present
-
-- name: Add Oracle JDK apt repository
-  apt_repository:
-    repo: "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main"
-    update_cache: true
-    state: present
-
-- name: Accept Oracle license
-  debconf:
-    name: oracle-java8-installer
-    question: shared/accepted-oracle-license-v1-1
-    value: "true"
-    vtype: select
-
-- name: Install Oracle JDK
+- name: Install OpenJDK
   apt:
-    name: oracle-java8-installer
+    name: openjdk-8-jdk
     state: present
 
 - name: Setup jenkins-agent


### PR DESCRIPTION
Oracle JDK 8 is deprecated, so I wasn't able to install Java during the setup of a Jenkins Agent.
I switched to the OpenJDK 8 and it worked.