### PR TITLE
Set jenkins UID to 999

### DIFF
--- a/roles/jenkins-agent/tasks/jenkins-agent.yml
+++ b/roles/jenkins-agent/tasks/jenkins-agent.yml
@@ -25,6 +25,7 @@
 - name: Create jenkins-agent user
   user:
     name: "{{ jenkins_agent_user }}"
+    uid: "{{ jenkins_agent_user_uid }}"
     append: true
     groups: "{{ jenkins_agent_additional_groups }}"
     home: "{{ jenkins_agent_home }}"


### PR DESCRIPTION
In a multi stage pipeline based on Docker images, the second stage fails because of this error:

`Caused by: hudson.plugins.git.GitException: Command "git config remote.origin.url http://..." returned status code 255:
stdout: 
stderr: error: could not lock config file .git/config: Permission denied`

I was able to solve the problem by changing the UID of `jenkins` user in 999.